### PR TITLE
gitlab-ci.yml: make sure path ./public/pool/ exists storage of *.deb …

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ pages:
     - ./package-binutils.sh
     - dpkg -i ./packaging-build/binutils-pru_*.deb
     - mkdir -p ./public/dists/stable/main/binary-arm64/
+    - mkdir -p ./public/pool/
     - cp -v ./packaging-build/*.deb ./public/pool/ || true
     - cp -v ./packaging-build/*.build ./public/ || true
     - cp -v ./packaging-build/*.buildinfo ./public/ || true


### PR DESCRIPTION
From the build log, https://openbeagle.org/beagleboard/gnupru/-/jobs/19671 looks like we are missing missing the pool directory.

https://beagleboard.beagleboard.io/gnupru/